### PR TITLE
stdlib_experimental_io: addition of a parser and characters "+" and "s/b" (for stream)

### DIFF
--- a/src/tests/io/Makefile.manual
+++ b/src/tests/io/Makefile.manual
@@ -5,7 +5,7 @@ OBJS = ../../stdlib_experimental_error.o \
 .PHONY: all clean
 .SUFFIXES: .f90 .o
 
-all: test_loadtxt test_savetxt
+all: test_loadtxt test_savetxt test_open
 
 test_loadtxt: test_loadtxt.f90 $(OBJS)
 	$(FC) $(FCFLAGS) $(CPPFLAGS) $< -o $@ $(OBJS)
@@ -13,8 +13,11 @@ test_loadtxt: test_loadtxt.f90 $(OBJS)
 test_savetxt: test_savetxt.f90 $(OBJS)
 	$(FC) $(FCFLAGS) $(CPPFLAGS) $< -o $@ $(OBJS)
 
+test_open: test_open.f90 $(OBJS)
+	$(FC) $(FCFLAGS) $(CPPFLAGS) $< -o $@ $(OBJS)
+
 %.o: %.mod
 
 clean:
-	$(RM) test_loadtxt test_savetxt
+	$(RM) test_loadtxt test_savetxt test_open
 	$(RM) *.o *.mod

--- a/src/tests/io/test_open.f90
+++ b/src/tests/io/test_open.f90
@@ -6,6 +6,7 @@ implicit none
 character(:), allocatable :: filename
 integer :: u, a(3)
 
+! Text file
 filename = get_outpath() // "/io_open.dat"
 
 ! Test mode "w"
@@ -30,6 +31,32 @@ read(u, *) a
 call assert(all(a == [4, 5, 6]))
 close(u)
 
+
+
+! Stream file
+filename = get_outpath() // "/io_open.stream"
+
+! Test mode "w"
+u = open(filename, "wb")
+write(u) 1, 2, 3
+close(u)
+
+! Test mode "r"
+u = open(filename, "rb")
+read(u) a
+call assert(all(a == [1, 2, 3]))
+close(u)
+
+! Test mode "a"
+u = open(filename, "ab")
+write(u) 4, 5, 6
+close(u)
+u = open(filename, "rb")
+read(u) a
+call assert(all(a == [1, 2, 3]))
+read(u) a
+call assert(all(a == [4, 5, 6]))
+close(u)
 
 contains
 


### PR DESCRIPTION
My idea is based on the fact that the mode can be only 3 characters:
- first character: r/w/a/x
-second character: blank or "+"
-third character: t/b/s(?)/u(?_

The function `parse_mode` should return a mode corresponding to these 3 possibilities.

It also avoids many `if` statements as implemented previously.